### PR TITLE
Improves event subscription management

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,27 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js & Configure Auth
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://packages.goreng.dev
+          always-auth: true
+          token: ${{ secrets.NPM_TOKEN }}
+          
+      - name: Publish package
+        run: npm publish --registry https://packages.goreng.dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/Events/BaseEventListener.cs
+++ b/Events/BaseEventListener.cs
@@ -6,25 +6,28 @@ namespace Framework.Events
     {
         private readonly IEventContainer<T> _container;
         private readonly bool _repeat;
-        
-        internal BaseEventListener(IEventContainer<T> container, bool repeat)
+
+        public BaseEventListener(IEventContainer<T> container, bool repeat)
         {
             _container = container;
             _repeat = repeat;
         }
-        
-        public event EventHandler<T> Subscribe
-        {
-            add
-            {
-                _container.publisher += value;
 
-                if (_container.lastState != null && _repeat)
-                {
-                    value.Invoke(null, _container.lastState);
-                }
+        public IDisposable Subscribe(EventHandler<T> handler)
+        {
+            _container.publisher += handler;
+            
+            if (_container.lastState != null && _repeat)
+            {
+                _container.publisher.Invoke(this, _container.lastState);
             }
-            remove => _container.publisher -= value;
+            
+            return new EventSubscription<T>(this, handler);
+        }
+
+        public void Unsubscribe(EventHandler<T> handler)
+        {
+            _container.publisher -= handler;
         }
     }
 }

--- a/Events/DisposeBag.cs
+++ b/Events/DisposeBag.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Framework.Events
+{
+    /// <summary>
+    /// A container for managing multiple <see cref="IDisposable"/> instances, disposing them all when this bag is disposed.
+    /// </summary>
+    public class DisposeBag : IDisposable
+    {
+        /// <summary>
+        /// List of disposables to be disposed when <see cref="Dispose"/> is called.
+        /// </summary>
+        private readonly List<IDisposable> _disposables = new List<IDisposable>();
+        
+        /// <summary>
+        /// Indicates whether this <see cref="DisposeBag"/> has already been disposed.
+        /// </summary>
+        private bool _isDisposed;
+        
+        /// <summary>
+        /// Adds an <see cref="IDisposable"/> instance to the bag.
+        /// </summary>
+        /// <param name="disposable">The disposable instance to add.</param>
+        /// <remarks>
+        /// Disposables added after the bag has been disposed will still be disposed immediately.
+        /// </remarks>
+        public void Add(IDisposable disposable)
+        {
+            if (_isDisposed)
+            {
+                // If already disposed, dispose the item immediately to maintain consistency.
+                disposable.Dispose();
+                return;
+            }
+
+            _disposables.Add(disposable);
+        }
+        
+        /// <summary>
+        /// Disposes all <see cref="IDisposable"/> instances in the bag.
+        /// </summary>
+        /// <remarks>
+        /// Calling Dispose multiple times has no additional effect.
+        /// </remarks>
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _isDisposed = true;
+            
+            foreach (var disposable in _disposables)
+            {
+                try
+                {
+                    disposable.Dispose();
+                }
+                catch (Exception ex)
+                {
+                    // Optionally log or handle exceptions from disposal of individual items
+                    Debug.LogError($"Error disposing object of type {disposable.GetType()}: {ex}");
+                }
+            }
+
+            _disposables.Clear();
+        }
+    }
+}

--- a/Events/DisposeBag.cs.meta
+++ b/Events/DisposeBag.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: c9393e9a2b27452e902dac87d777e6ca
+timeCreated: 1747574177

--- a/Events/EventSubscription.cs
+++ b/Events/EventSubscription.cs
@@ -1,0 +1,21 @@
+﻿using System;
+
+namespace Framework.Events
+{
+    public class EventSubscription<TEvent> : IDisposable
+    {
+        private readonly IEventListener<TEvent> _listener;
+        private readonly EventHandler<TEvent> _handler;
+
+        public EventSubscription(IEventListener<TEvent> listener, EventHandler<TEvent> handler)
+        {
+            _listener = listener;
+            _handler = handler;
+        }
+
+        public void Dispose()
+        {
+            _listener.Unsubscribe(_handler);
+        }
+    }
+}

--- a/Events/EventSubscription.cs.meta
+++ b/Events/EventSubscription.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: bf863332e75c450a9c4ad438da291cd5
+timeCreated: 1747642211

--- a/Events/Extensions.meta
+++ b/Events/Extensions.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 02b5d0c923284ddca620a50ef5588ce2
+timeCreated: 1747574193

--- a/Events/Extensions/IDisposableExtensions.cs
+++ b/Events/Extensions/IDisposableExtensions.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace Framework.Events.Extensions
+{
+    public static class IDisposableExtensions {
+
+        public static void AddToDisposables(this IDisposable disposable, DisposeBag bag)
+        {
+            bag.Add(disposable);   
+        }
+    }
+}

--- a/Events/Extensions/IDisposableExtensions.cs.meta
+++ b/Events/Extensions/IDisposableExtensions.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3f73b9c4d8624b2dad0f3421ca20eb64
+timeCreated: 1747574199

--- a/Events/IDisposableEventProducer.cs
+++ b/Events/IDisposableEventProducer.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Framework.Events
+{
+    public interface IDisposableEventProducer<T>: IEventProducer<T>, IDisposable
+    {
+        
+    }
+}

--- a/Events/IDisposableEventProducer.cs.meta
+++ b/Events/IDisposableEventProducer.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7f7213fea23c40a4a411940e223288d0
+timeCreated: 1747723810

--- a/Events/IEventListener.cs
+++ b/Events/IEventListener.cs
@@ -4,6 +4,7 @@ namespace Framework.Events
 {
     public interface IEventListener<T>
     {
-        event EventHandler<T> Subscribe;
+        public IDisposable Subscribe(EventHandler<T> handler);
+        public void Unsubscribe(EventHandler<T> handler);
     }
 }


### PR DESCRIPTION
Introduces `DisposeBag` and `EventSubscription` to streamline event
subscription management. This prevents memory leaks by ensuring
subscriptions are properly disposed of when no longer needed.

The `BaseEventListener` now returns an `IDisposable` on subscribe which
handles the unsubscribe logic upon disposal.
