### PR TITLE
Adds cancellation support to DisposeBag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dev.goreng.events",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "displayName": "Event Framework",
   "description": "Easily manage events between objects",
   "unity": "2022.3",


### PR DESCRIPTION
Adds a `CancellationTokenSource` to the `DisposeBag` to enable cancellation of asynchronous operations when the bag is disposed.

- Provides a way to signal the cancellation of ongoing tasks associated with the disposables managed by the bag.
- Ensures proper cleanup and prevents potential resource leaks by cancelling and disposing of the token source.
- Updates the package version.